### PR TITLE
Create reproducible builds for TDP Hadoop

### DIFF
--- a/dev-support/bin/dist-tar-stitching
+++ b/dev-support/bin/dist-tar-stitching
@@ -21,6 +21,9 @@ VERSION=$1
 # project.build.directory
 BASEDIR=$2
 
+# Date used by the tar command
+OUTPUT_TIMESTAMP="${OUTPUT_TIMESTAMP:-`date`}"
+
 function run()
 {
   declare res
@@ -37,8 +40,8 @@ function run()
 }
 
 
-run tar cf "hadoop-${VERSION}.tar" "hadoop-${VERSION}"
-run gzip -f "hadoop-${VERSION}.tar"
+run tar cf "hadoop-${VERSION}.tar" "hadoop-${VERSION}" --sort=name --owner=root:0 --group=root:0 --mtime="${OUTPUT_TIMESTAMP}"
+run gzip -n -f "hadoop-${VERSION}.tar"
 echo
 echo "Hadoop dist tar available at: ${BASEDIR}/hadoop-${VERSION}.tar.gz"
 echo

--- a/hadoop-build-tools/pom.xml
+++ b/hadoop-build-tools/pom.xml
@@ -29,6 +29,15 @@
     <failIfNoTests>false</failIfNoTests>
   </properties>
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.3.0</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <resources>
       <resource>
         <directory>${project.basedir}/target/extra-resources</directory>

--- a/hadoop-client-modules/hadoop-client-api/pom.xml
+++ b/hadoop-client-modules/hadoop-client-api/pom.xml
@@ -229,7 +229,7 @@
                   </relocations>
                   <transformers>
                     <!-- Needed until MSHADE-182 -->
-                    <transformer implementation="org.apache.hadoop.maven.plugin.shade.resource.ServicesResourceTransformer"/>
+                    <!-- <transformer implementation="org.apache.hadoop.maven.plugin.shade.resource.ServicesResourceTransformer"/> -->
                     <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
                     <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
                       <resource>NOTICE.txt</resource>

--- a/hadoop-common-project/hadoop-auth/pom.xml
+++ b/hadoop-common-project/hadoop-auth/pom.xml
@@ -211,13 +211,13 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <executions>
-          <execution>
+          <!-- <execution>
             <id>prepare-jar</id>
             <phase>prepare-package</phase>
             <goals>
               <goal>jar</goal>
             </goals>
-          </execution>
+          </execution> -->
           <execution>
             <id>prepare-test-jar</id>
             <phase>prepare-package</phase>

--- a/hadoop-dist/pom.xml
+++ b/hadoop-dist/pom.xml
@@ -207,6 +207,9 @@
                       <argument>${project.version}</argument>
                       <argument>${project.build.directory}</argument>
                     </arguments>
+                    <environmentVariables>
+                      <OUTPUT_TIMESTAMP>${project.build.outputTimestamp}</OUTPUT_TIMESTAMP>
+                    </environmentVariables>
                 </configuration>
               </execution>
             </executions>

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/pom.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/pom.xml
@@ -36,7 +36,7 @@
     <httpfs.source.repository>REPO NOT AVAIL</httpfs.source.repository>
     <httpfs.source.revision>REVISION NOT AVAIL</httpfs.source.revision>
     <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ssZ</maven.build.timestamp.format>
-    <httpfs.build.timestamp>${maven.build.timestamp}</httpfs.build.timestamp>
+    <httpfs.build.timestamp>${project.build.outputTimestamp}</httpfs.build.timestamp>
     <kerberos.realm>LOCALHOST</kerberos.realm>
     <test.exclude.kerberos.test>**/TestHttpFSWithKerberos.java</test.exclude.kerberos.test>
   </properties>

--- a/hadoop-maven-plugins/src/main/java/org/apache/hadoop/maven/plugin/versioninfo/VersionInfoMojo.java
+++ b/hadoop-maven-plugins/src/main/java/org/apache/hadoop/maven/plugin/versioninfo/VersionInfoMojo.java
@@ -94,6 +94,9 @@ public class VersionInfoMojo extends AbstractMojo {
    * @return String representing current build time
    */
   private String getBuildTime() {
+    if (project.getProperties().getProperty("project.build.outputTimestamp") != null) {
+      return project.getProperties().getProperty("project.build.outputTimestamp");
+    }
     DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm'Z'");
     dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
     return dateFormat.format(new Date());

--- a/hadoop-project-dist/pom.xml
+++ b/hadoop-project-dist/pom.xml
@@ -376,7 +376,7 @@
                     <!-- Using Unix script to preserve symlinks -->
                     <echo file="${project.build.directory}/dist-maketar.sh">
                       cd "${project.build.directory}"
-                      tar cf - ${project.artifactId}-${project.version} --sort=name --owner=root:0 --group=root:0 --mtime='${project.build.outputTimestamp}' | gzip -n | gzip > ${project.artifactId}-${project.version}.tar.gz
+                      tar cf - ${project.artifactId}-${project.version} --sort=name --owner=root:0 --group=root:0 --mtime='${project.build.outputTimestamp}' | gzip -n > ${project.artifactId}-${project.version}.tar.gz
                     </echo>
                     <exec executable="${shell-executable}" dir="${project.build.directory}" failonerror="true">
                       <arg line="./dist-maketar.sh"/>

--- a/hadoop-project-dist/pom.xml
+++ b/hadoop-project-dist/pom.xml
@@ -66,7 +66,7 @@
         <artifactId>maven-jar-plugin</artifactId>
         <executions>
           <execution>
-            <id>prepare-jar</id>
+            <id>default-jar</id>
             <phase>prepare-package</phase>
             <goals>
               <goal>jar</goal>
@@ -376,7 +376,7 @@
                     <!-- Using Unix script to preserve symlinks -->
                     <echo file="${project.build.directory}/dist-maketar.sh">
                       cd "${project.build.directory}"
-                      tar cf - ${project.artifactId}-${project.version} | gzip > ${project.artifactId}-${project.version}.tar.gz
+                      tar cf - ${project.artifactId}-${project.version} --sort=name --owner=root:0 --group=root:0 --mtime='${project.build.outputTimestamp}' | gzip -n | gzip > ${project.artifactId}-${project.version}.tar.gz
                     </echo>
                     <exec executable="${shell-executable}" dir="${project.build.directory}" failonerror="true">
                       <arg line="./dist-maketar.sh"/>

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -122,11 +122,11 @@
     <maven-clean-plugin.version>2.5</maven-clean-plugin.version>
     <maven-compiler-plugin.version>3.1</maven-compiler-plugin.version>
     <maven-install-plugin.version>2.5.1</maven-install-plugin.version>
-    <maven-resources-plugin.version>2.6</maven-resources-plugin.version>
-    <maven-shade-plugin.version>2.4.3</maven-shade-plugin.version>
-    <maven-jar-plugin.version>2.5</maven-jar-plugin.version>
-    <maven-war-plugin.version>3.1.0</maven-war-plugin.version>
-    <maven-source-plugin.version>2.3</maven-source-plugin.version>
+    <maven-resources-plugin.version>3.3.0</maven-resources-plugin.version>
+    <maven-shade-plugin.version>3.4.1</maven-shade-plugin.version>
+    <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
+    <maven-war-plugin.version>3.3.2</maven-war-plugin.version>
+    <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
     <maven-pdf-plugin.version>1.2</maven-pdf-plugin.version>
     <maven-remote-resources-plugin.version>1.5</maven-remote-resources-plugin.version>
     <build-helper-maven-plugin.version>1.9</build-helper-maven-plugin.version>

--- a/hadoop-tools/hadoop-distcp/pom.xml
+++ b/hadoop-tools/hadoop-distcp/pom.xml
@@ -187,7 +187,7 @@
         </configuration>
         <executions>
           <execution>
-            <id>prepare-jar</id>
+            <id>default-jar</id>
             <phase>prepare-package</phase>
             <goals>
               <goal>jar</goal>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-distributedshell/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-distributedshell/pom.xml
@@ -184,8 +184,8 @@
                <mainClass>org.apache.hadoop.yarn.applications.distributedshell.Client</mainClass>
              </manifest>
            </archive>
-        </configuration> -->
-      </plugin>
+        </configuration>
+      </plugin> -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-distributedshell/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-distributedshell/pom.xml
@@ -166,16 +166,16 @@
 
   <build>
     <plugins>
-      <plugin>
+      <!-- <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <executions>
           <execution>
             <goals>
               <goal>jar</goal>
-            </goals>
+            </goals> -->
             <!-- strictly speaking, the unit test is really a regression test. It
                  needs the main jar to be available to be able to run. -->
-            <phase>test-compile</phase>
+            <!-- <phase>test-compile</phase>
           </execution>
         </executions>
         <configuration>
@@ -184,7 +184,7 @@
                <mainClass>org.apache.hadoop.yarn.applications.distributedshell.Client</mainClass>
              </manifest>
            </archive>
-        </configuration>
+        </configuration> -->
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-server/hadoop-yarn-server-timelineservice-hbase-server-1/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-server/hadoop-yarn-server-timelineservice-hbase-server-1/pom.xml
@@ -145,8 +145,9 @@
           <plugin>
             <artifactId>maven-assembly-plugin</artifactId>
             <configuration>
-              <descriptor>src/assembly/coprocessor.xml</descriptor>
-              <attach>true</attach>
+              <descriptors>
+                <descriptor>src/assembly/coprocessor.xml</descriptor>
+              </descriptors>
             </configuration>
             <executions>
               <execution>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-server/hadoop-yarn-server-timelineservice-hbase-server-2/pom.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-timelineservice-hbase/hadoop-yarn-server-timelineservice-hbase-server/hadoop-yarn-server-timelineservice-hbase-server-2/pom.xml
@@ -162,10 +162,9 @@
                 <goals>
                   <goal>single</goal>
                 </goals>
-                <configuration>
+                <descriptors>
                   <descriptor>src/assembly/coprocessor.xml</descriptor>
-                  <attach>true</attach>
-                </configuration>
+                </descriptors>
               </execution>
             </executions>
           </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
   </organization>
 
   <properties>
+    <project.build.outputTimestamp>2023-01-01T00:00:00Z</project.build.outputTimestamp>
     <distMgmtSnapshotsId>apache.snapshots.https</distMgmtSnapshotsId>
     <distMgmtSnapshotsName>Apache Development Snapshot Repository</distMgmtSnapshotsName>
     <distMgmtSnapshotsUrl>https://repository.apache.org/content/repositories/snapshots</distMgmtSnapshotsUrl>

--- a/pom.xml
+++ b/pom.xml
@@ -94,8 +94,8 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <maven-deploy-plugin.version>2.8.1</maven-deploy-plugin.version>
     <maven-site-plugin.version>3.6</maven-site-plugin.version>
     <maven-stylus-skin.version>1.5</maven-stylus-skin.version>
-    <maven-antrun-plugin.version>1.7</maven-antrun-plugin.version>
-    <maven-assembly-plugin.version>2.4</maven-assembly-plugin.version>
+    <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
+    <maven-assembly-plugin.version>3.4.2</maven-assembly-plugin.version>
     <maven-dependency-plugin.version>3.0.2</maven-dependency-plugin.version>
     <maven-enforcer-plugin.version>3.0.0-M1</maven-enforcer-plugin.version>
     <maven-javadoc-plugin.version>3.0.0-M1</maven-javadoc-plugin.version>


### PR DESCRIPTION
This PR aims to achieve reproducibility in TDP Hadoop. See issue #1 

Changes in this PR:

- hadoop-maven-plugin: return `project.build.outputTimestamp` maven properties if present instead of system date in `getDate` method.

- Add `project.build.outputTimestamp` in a few places to enable reproducibility

- Maven plugins upgrade:

  maven-antrun-plugin.version: 1.7 -> 3.1.0
  maven-assembly-plugin.version: 2.4 -> 3.4.2
  maven-jar-plugin.version: 2.5 -> 3.3.0
  maven-resources-plugin.version: 2.6 -> 3.3.0
  maven-shade-plugin.version: 2.4.3 -> 3.4.1
  maven-source-plugin.version: 2.3 -> 3.2.1
  maven-war-plugin.version: 3.1.0 -> 3.3.2

These Maven plugin updates breaks compilation of some module. According changes have been made in their pom.xml.

A more thorough investigation is still needed to verify that the binaries included after theses changes are still valid. They have not yet been tested in a Hadoop cluster